### PR TITLE
docs:  add doc strings to collect, render & update_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,29 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.1.2](https://github.com/mkdocstrings/handler-template/releases/tag/0.1.2) - 2023-01-06
+
+<small>[Compare with 0.1.1](https://github.com/mkdocstrings/handler-template/compare/0.1.1...0.1.2)</small>
+
+### Code Refactoring
+
+- Added doc strings to collect/render to help a user implement their custom feature set.
 
 ## [0.1.1](https://github.com/mkdocstrings/handler-template/releases/tag/0.1.1) - 2022-05-02
 
 <small>[Compare with 0.1.0](https://github.com/mkdocstrings/handler-template/compare/0.1.0...0.1.1)</small>
 
 ### Code Refactoring
+
 - Stop using deprecated base classes ([ef08365](https://github.com/mkdocstrings/handler-template/commit/ef08365af23d8ba78bda66ff5da93e12f43f1088) by Timothée Mazzucotelli).
 - Update from upstream template Copier PDM.
 
 ## [0.1.0](https://github.com/mkdocstrings/copier-pdm/releases/tag/0.1.0) - 2022-03-06
 
 ### Code Refactoring
+
 - Fit *mkdocstrings* handlers structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,18 @@
 # Changelog
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-## [0.1.2](https://github.com/mkdocstrings/handler-template/releases/tag/0.1.2) - 2023-01-06
-
-<small>[Compare with 0.1.1](https://github.com/mkdocstrings/handler-template/compare/0.1.1...0.1.2)</small>
-
-### Code Refactoring
-
-- Added doc strings to collect/render to help a user implement their custom feature set.
 
 ## [0.1.1](https://github.com/mkdocstrings/handler-template/releases/tag/0.1.1) - 2022-05-02
 
 <small>[Compare with 0.1.0](https://github.com/mkdocstrings/handler-template/compare/0.1.0...0.1.1)</small>
 
 ### Code Refactoring
-
 - Stop using deprecated base classes ([ef08365](https://github.com/mkdocstrings/handler-template/commit/ef08365af23d8ba78bda66ff5da93e12f43f1088) by Timothée Mazzucotelli).
 - Update from upstream template Copier PDM.
 
 ## [0.1.0](https://github.com/mkdocstrings/copier-pdm/releases/tag/0.1.0) - 2022-03-06
 
 ### Code Refactoring
-
 - Fit *mkdocstrings* handlers structure.

--- a/project/src/mkdocstrings_handlers/{{python_package_import_name}}/handler.py.jinja
+++ b/project/src/mkdocstrings_handlers/{{python_package_import_name}}/handler.py.jinja
@@ -46,9 +46,33 @@ class {{ language|title }}Handler(BaseHandler):
     """  # noqa: E501
 
     def collect(self, identifier: str, config: dict) -> CollectorItem:  # noqa: D102
+        """Collect data given an identifier and selection configuration.
+
+        In the implementation, you typically call a subprocess that returns JSON, and load that JSON again into
+        a Python dictionary for example, though the implementation is completely free.
+
+        Arguments:
+            identifier: An identifier that was found in a markdown document for which to collect data. For example,
+                in Python, it would be 'mkdocstrings.handlers' to collect documentation about the handlers module.
+                It can be anything that you can feed to the tool of your choice.
+            config: Configuration options for the tool you use to collect data. Typically called "selection" because
+                these options modify how the objects or documentation are "selected" in the source code.
+
+        Returns:
+            Anything you want, as long as you can feed it to the renderer's `render` method.
+        """
         raise CollectionError("Implement me!")
 
     def render(self, data: CollectorItem, config: dict) -> str:  # noqa: D102
+        """Render a template using provided data and configuration options.
+
+        Arguments:
+            data: The data to render that was collected above in `collect()`.
+            config: The rendering options.
+
+        Returns:
+            The rendered template as HTML.
+        """
         raise PluginError("Implement me!")
 
         # final_config = {**self.default_config, **config}
@@ -59,7 +83,14 @@ class {{ language|title }}Handler(BaseHandler):
         # )
 
     def update_env(self, md: Markdown, config: dict) -> None:  # noqa: D102 (ignore missing docstring)
-        super().update_env(md, config)
+        """Update the Jinja environment with any custom settings/filters/options for this handler.
+
+        Arguments:
+            md: The Markdown instance. Useful to add functions able to convert Markdown into the environment filters.
+            config: Configuration options for `mkdocs` and `mkdocstrings`, read from `mkdocs.yml`. See the source code
+                of [mkdocstrings.plugin.MkdocstringsPlugin.on_config][] to see what's in this dictionary.
+        """
+        super().update_env(md, config) # Add some mkdocstrings default filters such as highlight and convert_markdown
         self.env.trim_blocks = True
         self.env.lstrip_blocks = True
         self.env.keep_trailing_newline = False

--- a/project/src/mkdocstrings_handlers/{{python_package_import_name}}/handler.py.jinja
+++ b/project/src/mkdocstrings_handlers/{{python_package_import_name}}/handler.py.jinja
@@ -55,8 +55,8 @@ class {{ language|title }}Handler(BaseHandler):
             identifier: An identifier that was found in a markdown document for which to collect data. For example,
                 in Python, it would be 'mkdocstrings.handlers' to collect documentation about the handlers module.
                 It can be anything that you can feed to the tool of your choice.
-            config: Configuration options for the tool you use to collect data. Typically called "selection" because
-                these options modify how the objects or documentation are "selected" in the source code.
+            config: All configuration options for this handler either defined globally in `mkdocs.yml` or
+                locally overridden in an identifier block by the user.
 
         Returns:
             Anything you want, as long as you can feed it to the renderer's `render` method.
@@ -68,7 +68,8 @@ class {{ language|title }}Handler(BaseHandler):
 
         Arguments:
             data: The data to render that was collected above in `collect()`.
-            config: The rendering options.
+            config: All configuration options for this handler either defined globally in `mkdocs.yml` or
+                locally overridden in an identifier block by the user.
 
         Returns:
             The rendered template as HTML.


### PR DESCRIPTION
Trying to prevent others from some of the digging that I had to do. I copied in doc strings from mkdocstrings and tweaked them slightly.  Helpful to prevent the user from having to dig deeply in mkdocstrings when first getting started.